### PR TITLE
Fix "Cast of type SEL" warning, iOS 6.1

### DIFF
--- a/Pickers/ActionSheetDatePicker.m
+++ b/Pickers/ActionSheetDatePicker.m
@@ -74,7 +74,7 @@
     if ([target respondsToSelector:action])
         objc_msgSend(target, action, self.selectedDate, origin);
     else
-        NSAssert(NO, @"Invalid target/action ( %s / %s ) combination used for ActionSheetPicker", object_getClassName(target), (char *)action);
+        NSAssert(NO, @"Invalid target/action ( %s / %s ) combination used for ActionSheetPicker", object_getClassName(target), sel_getName(action));
 }
 
 - (void)eventForDatePicker:(id)sender {

--- a/Pickers/ActionSheetDistancePicker.m
+++ b/Pickers/ActionSheetDistancePicker.m
@@ -120,7 +120,7 @@
     if ([target respondsToSelector:action])
         objc_msgSend(target, action, [NSNumber numberWithInt:bigUnits], [NSNumber numberWithInt:smallUnits], origin);
     else
-        NSAssert(NO, @"Invalid target/action ( %s / %s ) combination used for ActionSheetPicker", object_getClassName(target), (char *)action);
+        NSAssert(NO, @"Invalid target/action ( %s / %s ) combination used for ActionSheetPicker", object_getClassName(target), sel_getName(action));
 }
 
 #pragma mark -

--- a/Pickers/ActionSheetStringPicker.m
+++ b/Pickers/ActionSheetStringPicker.m
@@ -98,7 +98,7 @@
 #pragma clang diagnostic pop
         return;
     }
-    NSLog(@"Invalid target/action ( %s / %s ) combination used for ActionSheetPicker", object_getClassName(target), (char *)successAction);
+    NSLog(@"Invalid target/action ( %s / %s ) combination used for ActionSheetPicker", object_getClassName(target), sel_getName(successAction));
 }
 
 - (void)notifyTarget:(id)target didCancelWithAction:(SEL)cancelAction origin:(id)origin {


### PR DESCRIPTION
Fixes 6.1 warning:
Cast of type 'SEL' (aka 'SEL *') to 'char *' is deprecated; use sel_getName instead

Thanks!
